### PR TITLE
Fix error handling in news creation response

### DIFF
--- a/src/app/admin/news/create/create.news.form.tsx
+++ b/src/app/admin/news/create/create.news.form.tsx
@@ -133,8 +133,7 @@ const CreateNewsForm = ({ apiBase, tags }: CraeteNewsProps) => {
 
         const response = await newsService.createNews(payload, selectedFile);
 
-        if (!response) setIsError(true);
-        else {
+        if (response) {
           setConfirmModal({
             isOpen: true,
             type: "success",
@@ -144,6 +143,8 @@ const CreateNewsForm = ({ apiBase, tags }: CraeteNewsProps) => {
               router.push(`/admin/news?page=1&pageSize=9&category=&title=`);
             },
           });
+        } else {
+          setIsError(true);
         }
       } catch (error) {
         console.log(error);


### PR DESCRIPTION
Improve error handling in the news creation process by ensuring that an error state is set when the response is not successful. This change enhances user feedback during the news creation workflow.