### PR TITLE
fix: update NewsInfo component to handle thumbnail and highlight image uploads with cropping functionality

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -39,6 +39,11 @@ const nextConfig: NextConfig = {
         hostname: "sxqybhqykgsfrqvzadzg.supabase.co",
         pathname: "/storage/v1/object/public/**",
       },
+      {
+        protocol: "https",
+        hostname: "vsjmwmltpowyiodyygeh.supabase.co",
+        pathname: "/**", 
+      },
     ],
   },
   async redirects() {

--- a/src/app/admin/news/[id]/news.info.tsx
+++ b/src/app/admin/news/[id]/news.info.tsx
@@ -10,7 +10,7 @@ import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import Image from "next/image";
 import { RHFSelect } from "@/components/form/RHFSelect";
-import { Button, MenuItem, Alert, Snackbar } from "@mui/material";
+import { Button, MenuItem, Alert, Snackbar, Modal } from "@mui/material";
 import { RHFDatePickerDayjs } from "@/components/form/RHFDatePicker";
 import { styled } from "@mui/material/styles";
 import { NewsService } from "@/core/service/news.service";
@@ -21,6 +21,7 @@ import {
   ConfirmModalProps,
 } from "@/components/modal/confirmModal";
 import { Tag } from "@/core/domain/list-type";
+import { CropImageCard } from "@/components/cropimagecard";
 
 dayjs.extend(buddhistEra);
 dayjs.locale("th");
@@ -37,6 +38,8 @@ const formSchema = z.object({
   dueDate: z.custom<Dayjs>().nullable(),
   tag: z.number(),
   detail: z.string().optional(),
+  thumbnail: z.instanceof(File).optional(),
+  highlight: z.instanceof(File).optional(),
 });
 
 type Inputs = z.infer<typeof formSchema>;
@@ -55,17 +58,13 @@ const VisuallyHiddenInput = styled("input")({
 
 const NewsInfo = ({ news, apiBase, categories }: NewsInfoProps) => {
   const [isEdit, setIsEdit] = useState(false);
-  const [selectedFile, setSelectedFile] = useState<File | null>(null);
-  const [confirmModal, setConfirmModal] = useState<ConfirmModalProps | null>(
-    null,
-  );
+  const [confirmModal, setConfirmModal] = useState<ConfirmModalProps | null>(null,);
   const [isError, setIsError] = useState(false);
 
-  const router = useRouter();
+  const [croppingFile, setCroppingFile] = useState<File | null>(null);
+  const [cropTarget, setCropTarget] = useState<"thumbnail" | "highlight" | null>(null);
 
-  const previewSrc = selectedFile
-    ? URL.createObjectURL(selectedFile)
-    : news.image;
+  const router = useRouter();
 
   const newsService = useMemo(() => {
     const newsRepository = new NewsRepository(apiBase);
@@ -75,6 +74,9 @@ const NewsInfo = ({ news, apiBase, categories }: NewsInfoProps) => {
   const {
     control,
     handleSubmit,
+    setValue,
+    watch,
+    reset,
     formState: { isDirty },
   } = useForm<Inputs>({
     resolver: zodResolver(formSchema),
@@ -84,72 +86,106 @@ const NewsInfo = ({ news, apiBase, categories }: NewsInfoProps) => {
       dueDate: news.dueDate ? dayjs(news.dueDate) : undefined,
       tag: news.tag.id,
       detail: news.detail,
+      thumbnail: undefined,
+      highlight: undefined,
     },
   });
 
-  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0] || null;
-    if (file) {
-      setSelectedFile(file);
-    } else {
-      setSelectedFile(null);
+  const thumbnailFile = watch("thumbnail");
+  const highlightFile = watch("highlight");
+
+  const previewThumbnailSrc = useMemo(() => {
+    if (thumbnailFile instanceof File) return URL.createObjectURL(thumbnailFile);
+
+    const baseUrl = (news)?.thumbnailURL;
+    return baseUrl ? `${baseUrl}?t=${Date.now()}` : "https://picsum.photos/400/300";
+  }, [thumbnailFile, news]);
+
+const previewHighlightSrc = useMemo(() => {
+    if (highlightFile instanceof File) return URL.createObjectURL(highlightFile);
+    
+    const baseUrl = (news)?.highlightURL;
+    return baseUrl ? `${baseUrl}?t=${Date.now()}` : "https://picsum.photos/800/400";
+}, [highlightFile, news]);
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>,target: "thumbnail"|"highlight") => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    setCroppingFile(file);
+    setCropTarget(target);
+    event.target.value = "";
+      
+  };
+
+  const handleUploadComplete = (file: File) => {
+    if (cropTarget === "thumbnail") {
+      setValue("thumbnail", file, { shouldValidate: true, shouldDirty: true });
+    } else if (cropTarget === "highlight") {
+      setValue("highlight", file, { shouldValidate: true, shouldDirty: true });
     }
+    setCroppingFile(null);
+    setCropTarget(null);
   };
 
   const handleCancel = () => {
-    if (isDirty || selectedFile) {
+    if (isDirty) {
       setConfirmModal({
         isOpen: true,
         type: "warning",
         onClose: () => setConfirmModal(null),
         onConfirm: () => {
+          reset();
           setIsEdit(false);
-          router.push(`/admin/news?page=1&pageSize=9&category=&title=`);
+          setConfirmModal(null);
         },
       });
     } else {
+      reset();
       setIsEdit(false);
-      router.push(`/admin/news?page=1&pageSize=9&category=&title=`);
     }
   };
 
+  
   const onSubmit: SubmitHandler<Inputs> = async (data) => {
-    if (isDirty || selectedFile) {
+    if (isDirty || thumbnailFile instanceof File || highlightFile instanceof File) {
       try {
         const payload: IUpdateNews = {
           title: data.title,
           tagID: data.tag,
           detail: data.detail,
           startDate: dayjs(data.startDate).toISOString(),
-
           dueDate: data.dueDate ? dayjs(data.dueDate).toISOString() : undefined,
         };
-
-        console.log(payload);
 
         const response = await newsService.updateNews(
           news.id,
           payload,
-          selectedFile,
+          thumbnailFile instanceof File ? thumbnailFile : null,
+          highlightFile instanceof File ? highlightFile : null
         );
 
-        if (!response) setIsError(true);
-        else {
-          setConfirmModal({
-            isOpen: true,
-            type: "success",
-            onClose: () => setConfirmModal(null),
-            onConfirm: () => {
-              setConfirmModal(null);
-              setIsEdit(false);
-              router.push(`/admin/news?page=1`);
-            },
-          });
+        if (!response) {
+            setIsError(true);
+            return;
         }
+
+        setConfirmModal({
+          isOpen: true,
+          type: "success",
+          onClose: () => setConfirmModal(null),
+          onConfirm: () => {
+            setConfirmModal(null);
+            setIsEdit(false);
+            router.push(`/admin/news?page=1`);
+            router.refresh();
+          },
+        });
       } catch (error) {
-        console.log(error);
+        console.error(error);
         setIsError(true);
       }
+    } else {
+      setIsEdit(false);
     }
   };
 
@@ -169,49 +205,69 @@ const NewsInfo = ({ news, apiBase, categories }: NewsInfoProps) => {
           ไม่สามารถเพิ่มข่าวสารได้
         </Alert>
       </Snackbar>
-      <h3 className="mb-6 font-bold">ข้อมูลข่าวสาร</h3>
+      <h3 className="mb-6 font-bold">{isEdit ? "แก้ไขข้อมูลข่าวสาร" : "ข้อมูลข่าวสาร"}</h3>
       <form className="gap-4 p-4" onSubmit={handleSubmit(onSubmit)}>
-        <div className="flex flex-col gap-4">
-          <div className="bg-neutral02 flex items-center justify-center rounded-lg">
-            {news || selectedFile ? (
-              <div className="group relative aspect-video w-full h-[560px] overflow-hidden rounded-xl">
+        <div className="flex flex-col gap-6">
+          <div className="grid grid-cols-1 md:grid-cols-5 gap-6">
+            
+            <div className="col-span-2 flex flex-col gap-2">
+              <label className={`text-sm font-medium ${isEdit ? "text-gray-700" : "text-gray-500"}`}>
+                ภาพหน้าปก
+              </label>
+              <div className="group relative aspect-[4/3] w-full overflow-hidden rounded-xl bg-gray-100 border border-gray-200">
                 <Image
-                  src={previewSrc}
-                  alt="Preview"
+                  src={previewThumbnailSrc}
+                  alt="Thumbnail Preview"
                   fill
-                  sizes="100vw"
-                  className="rounded-md object-cover"
+                  className="object-cover"
                 />
                 {isEdit && (
                   <div className="absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 transition-opacity duration-200 group-hover:opacity-100">
-                    <Button variant="contained" component="label">
+                    <Button variant="contained" component="label" sx={{ bgcolor: "#1E1B4B", "&:hover": { bgcolor: "#312E81" } }}>
+                      อัปโหลดรูปภาพ
                       <VisuallyHiddenInput
                         type="file"
                         accept="image/*"
-                        onChange={handleFileChange}
+                        onChange={(e) => handleFileChange(e, "thumbnail")}
                       />
-                      อัปโหลดรูปภาพ
                     </Button>
                   </div>
                 )}
               </div>
-            ) : (
-              isEdit && (
-                <Button variant="contained" component="label" size="large">
-                  อัปโหลดรูปภาพ
-                  <VisuallyHiddenInput
-                    type="file"
-                    accept="image/*"
-                    onChange={handleFileChange}
-                  />
-                </Button>
-              )
-            )}
+            </div>
+
+            <div className="col-span-3 flex flex-col gap-2">
+              <label className={`text-sm font-medium ${isEdit ? "text-gray-700" : "text-gray-500"}`}>
+                ภาพหัวเรื่อง
+              </label>
+              <div className="group relative aspect-[2/1] md:aspect-auto md:flex-1 w-full overflow-hidden rounded-xl bg-gray-100 border border-gray-200">
+                <Image
+                  src={previewHighlightSrc}
+                  alt="Highlight Preview"
+                  fill
+                  className="object-cover"
+                />
+                {isEdit && (
+                  <div className="absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 transition-opacity duration-200 group-hover:opacity-100">
+                    <Button variant="contained" component="label" sx={{ bgcolor: "#1E1B4B", "&:hover": { bgcolor: "#312E81" } }}>
+                      อัปโหลดรูปภาพ
+                      <VisuallyHiddenInput
+                        type="file"
+                        accept="image/*"
+                        onChange={(e) => handleFileChange(e, "highlight")}
+                      />
+                    </Button>
+                  </div>
+                )}
+              </div>
+            </div>
+  
           </div>
+
           <RHFTextField
             name="title"
             control={control}
-            label="หัวข้อข่าว"
+            label="หัวข้อ"
             disabled={!isEdit}
             required
             requiredMark
@@ -256,21 +312,32 @@ const NewsInfo = ({ news, apiBase, categories }: NewsInfoProps) => {
             <RHFDatePickerDayjs
               name="dueDate"
               control={control}
-              label="วันที่สิ้นสุด"
+              label="วันที่ครบกำหนด" 
               format="D MMMM YYYY"
-              placeholder="เลือกวันที่สิ้นสุด"
+              placeholder="เลือกวันที่ครบกำหนด"
               disabled={!isEdit}
             />
           </div>
         </div>
-        <div className="mt-4 flex justify-end">
+
+        <div className="mt-8 flex justify-end">
           {isEdit ? (
             <div className="flex gap-x-4">
-              <Button variant="outlined" onClick={handleCancel} size="large">
+              <Button 
+                variant="outlined" 
+                onClick={handleCancel} 
+                size="large"
+                sx={{ borderColor: "#1E1B4B", color: "#1E1B4B", px: 4 }}
+              >
                 ยกเลิก
               </Button>
-              <Button variant="contained" type="submit" size="large">
-                บันทึก
+              <Button 
+                variant="contained" 
+                type="submit" 
+                size="large"
+                sx={{ bgcolor: "#1E1B4B", "&:hover": { bgcolor: "#312E81" }, px: 4 }}
+              >
+                บันทึกข้อมูล
               </Button>
             </div>
           ) : (
@@ -279,6 +346,7 @@ const NewsInfo = ({ news, apiBase, categories }: NewsInfoProps) => {
                 variant="contained"
                 onClick={() => setIsEdit(true)}
                 size="large"
+                sx={{ bgcolor: "#1E1B4B", "&:hover": { bgcolor: "#312E81" }, px: 4 }}
               >
                 แก้ไขข้อมูล
               </Button>
@@ -286,6 +354,24 @@ const NewsInfo = ({ news, apiBase, categories }: NewsInfoProps) => {
           )}
         </div>
       </form>
+
+      <Modal open={!!croppingFile} onClose={() => setCroppingFile(null)}>
+        <div>
+          {croppingFile && cropTarget && (
+            <CropImageCard
+              file={croppingFile}
+              width={cropTarget === "thumbnail" ? 400 : 800}
+              height={cropTarget === "thumbnail" ? 300 : 400}
+              onUploadComplete={handleUploadComplete}
+              onCancel={() => {
+                setCroppingFile(null);
+                setCropTarget(null);
+              }}
+            />
+          )}
+        </div>
+      </Modal>
+
       {confirmModal && <ConfirmModal {...confirmModal} />}
     </div>
   );

--- a/src/core/domain/news.ts
+++ b/src/core/domain/news.ts
@@ -3,7 +3,8 @@ import { Tag } from "./list-type";
 export interface INews {
   id: number;
   title: string;
-  image: string;
+  thumbnailURL?: string;
+  highlightURL?: string;
   detail: string;
   startDate: Date;
   dueDate: Date | null;


### PR DESCRIPTION
This pull request updates the NewsInfo component to align with the newly updated backend database schema, transitioning from a single image system to supporting both thumbnail and highlight images. To support this data mapping, the INews interface was updated by replacing the deprecated image property with thumbnailURL and highlightURL.

On the UI side, the image preview section was restructured into a responsive dual-image layout, ensuring both the 4:3 thumbnail and the 2:1 highlight images display at an equal height for a consistent user experience. Furthermore, the zoom-on-hover effect on the images was removed to meet the latest design requirements, and the date input label was adjusted from "End Date" to "Due Date". For the upload functionality, the existing CropImageCard component was fully integrated, allowing users to independently crop the thumbnail and highlight images to their specific aspect ratios before submitting the form.

Lastly, to resolve the ongoing image rendering errors, the next.config.ts file was updated with a wildcard remote pattern (*.supabase.co). This ensures that Next.js can securely load and display images from any Supabase storage bucket without requiring manual domain additions in the future.