### PR TITLE
Add http proxy for public storage on sslip.io

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -42,13 +42,18 @@ const nextConfig: NextConfig = {
       {
         protocol: "https",
         hostname: "vsjmwmltpowyiodyygeh.supabase.co",
-        pathname: "/**", 
+        pathname: "/**",
       },
       {
         protocol: "https",
         hostname: "fwyfpkplevtnvrxzpyhq.supabase.co",
         pathname: "/storage/v1/object/public/**",
       },
+      {
+        protocol: "http",
+        hostname: "infra-supabase-c1c918-31-97-48-3.sslip.io",
+        pathname: "/storage/v1/object/public/**",
+      }
     ],
   },
   async redirects() {


### PR DESCRIPTION
Adds an http proxy entry for public storage on the sslip.io host at /storage/v1/object/public/**