### PR TITLE
feature/ACSWEBSITE-211

### DIFF
--- a/src/app/(public)/project/[id]/projectinfo.component.tsx
+++ b/src/app/(public)/project/[id]/projectinfo.component.tsx
@@ -40,12 +40,12 @@ const ProjectInfoComponent: FC<ProjectInfoProps> = ({ project }) => {
   };
 
   const getVisibleImages = () => {
+    const total = project?.assetsURL?.length || 0;
+    if (total === 0) return ["https://picsum.photos/seed/acs/140/90"];
+    const count = Math.min(3, total);
     const result = [];
-    for (let i = 0; i < 3; i++) {
-      result.push(
-        project?.assetsURL?.[(index + i) % (project?.assetsURL?.length || 1)] ?? 
-        "https://picsum.photos/seed/acs/140/90",
-      );
+    for (let i = 0; i < count; i++) {
+      result.push(project.assetsURL[(index + i) % total]);
     }
     return result;
   };


### PR DESCRIPTION
-แก้ไขฟังก์ชัน getVisibleImages ในไฟล์ projectinfo.component ให้แสดง asset ไม่เกินจำนวนรูปจริงที่มีอยู่ใน assetsURL โดยจำกัดจำนวนสูงสุดไว้ที่ 3 รูป